### PR TITLE
feat: add OpenCode GitHub Actions workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,32 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+       - name: Checkout repository
+         uses: actions/checkout@v6
+         with:
+           fetch-depth: 1
+           persist-credentials: false
+
+       - name: Run OpenCode
+         uses: anomalyco/opencode/github@latest
+         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+         with:
+          model: anthropic/claude-sonnet-4-20250514


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/opencode.yml` — GitHub Actions workflow that triggers OpenCode AI assistant on issue/PR comments containing `/oc` or `/opencode`
- Uses `anomalyco/opencode/github@latest` action with Claude Sonnet model via `ANTHROPIC_API_KEY` secret

## Test plan

- [ ] Add `ANTHROPIC_API_KEY` secret to repository settings
- [ ] Comment `/oc` on any issue or PR to trigger the workflow
- [ ] Verify OpenCode responds with AI-assisted code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)